### PR TITLE
Realistic Item Drops enhancement and optimisations

### DIFF
--- a/data/items/functions/_menu.mcfunction
+++ b/data/items/functions/_menu.mcfunction
@@ -1,0 +1,2 @@
+
+function items:menu

--- a/data/items/functions/_reinstall.mcfunction
+++ b/data/items/functions/_reinstall.mcfunction
@@ -1,0 +1,2 @@
+
+function items:reinstall

--- a/data/items/functions/_uninstall.mcfunction
+++ b/data/items/functions/_uninstall.mcfunction
@@ -1,0 +1,2 @@
+
+function items:uninstall

--- a/data/items/functions/as_break.mcfunction
+++ b/data/items/functions/as_break.mcfunction
@@ -1,4 +1,14 @@
-summon item ~ ~ ~ {Tags:["sb.pickup"],Item:{id:"minecraft:dirt",Count:1b},PickupDelay:1}
-data modify entity @e[tag=sb.pickup,limit=1,sort=nearest] Item set from entity @s HandItems[1]
-execute as @e[type=item,limit=1,sort=nearest,tag=sb.pickup] at @s run tp @s ~ ~1.3 ~
+
+#Summon the item
+summon item ~ ~ ~ {Tags:["sb.pickup"],Item:{id:"minecraft:dirt",Count:1b},PickupDelay:1s}
+
+#Store into a storage to avoid selector usage (@e)
+data modify storage items:main temp set from entity @s HandItems[1]
+
+#Replace the item
+execute as @e[type=item,limit=1,sort=nearest,tag=sb.pickup] at @s run function items:as_break_2
+
+#Kill the armor_stand
+scoreboard players remove #as_marker_count sb_items.data 1
 kill @s
+

--- a/data/items/functions/as_break_2.mcfunction
+++ b/data/items/functions/as_break_2.mcfunction
@@ -1,0 +1,4 @@
+
+data modify entity @s Item set from storage items:main temp
+tp @s ~ ~1.3 ~
+

--- a/data/items/functions/as_loops.mcfunction
+++ b/data/items/functions/as_loops.mcfunction
@@ -1,0 +1,7 @@
+
+# Armor stand manual gravity to put the entity in the floor
+execute if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
+
+# Detecting a player nearby to drop the item
+execute if entity @e[type=player,distance=..1.2] run function items:as_break
+

--- a/data/items/functions/as_loops.mcfunction
+++ b/data/items/functions/as_loops.mcfunction
@@ -5,3 +5,6 @@ execute if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
 # Detecting a player nearby to drop the item
 execute if entity @e[type=player,distance=..1.2] run function items:as_break
 
+# Despawning system
+execute if score .despawns ridsb.settings matches 1 if entity @s[tag=!global.ignore,tag=!global.ignore.kill] run function items:despawn_score
+

--- a/data/items/functions/as_on_ground.mcfunction
+++ b/data/items/functions/as_on_ground.mcfunction
@@ -4,6 +4,7 @@ data modify entity @s NoGravity set value 1b
 data modify entity @s Marker set value 1b
 tag @s remove sb.check_ground
 
+schedule function items:schedules/as_loops 1t replace
 scoreboard players add #as_marker_count sb_items.data 1
 tag @s add sb.is_marker
 

--- a/data/items/functions/as_on_ground.mcfunction
+++ b/data/items/functions/as_on_ground.mcfunction
@@ -4,3 +4,6 @@ data modify entity @s NoGravity set value 1b
 data modify entity @s Marker set value 1b
 tag @s remove sb.check_ground
 
+scoreboard players add #as_marker_count sb_items.data 1
+tag @s add sb.is_marker
+

--- a/data/items/functions/as_on_ground.mcfunction
+++ b/data/items/functions/as_on_ground.mcfunction
@@ -1,0 +1,6 @@
+
+scoreboard players remove #as_count sb_items.data 1
+data modify entity @s NoGravity set value 1b
+data modify entity @s Marker set value 1b
+tag @s remove sb.check_ground
+

--- a/data/items/functions/as_place.mcfunction
+++ b/data/items/functions/as_place.mcfunction
@@ -1,18 +1,17 @@
+
+#Summon visual
 summon armor_stand ~ ~ ~ {ShowArms:1b,Pose:{LeftArm:[0f,0f,0f],RightArm:[0f,0f,0f]},Invisible:1b,Tags:["sb.item_drop","global.ignore.kill","global.ignore.pos","global.ignore"],Silent:1b,Invulnerable:1b}
 
-execute unless entity @p[distance=..2,predicate=items:sprinting] run data modify entity @e[tag=sb.item_drop,limit=1,sort=nearest,tag=!sb.completed] Motion set from entity @s Motion
+#Store result of player sprinting check
+scoreboard players set #success sb.lifetime 0
+execute store success score #success sb.lifetime if entity @p[distance=..2,predicate=items:sprinting]
 
-execute if entity @p[distance=..2,predicate=items:sprinting] run execute store result entity @e[tag=sb.item_drop,limit=1,sort=nearest,tag=!sb.completed] Motion[0] double 0.001 run data get entity @s Motion[0] 3000
+#Store in a storage item nbt to avoid selector usage.
+data modify storage items:main temp set from entity @s
 
-execute if entity @p[distance=..2,predicate=items:sprinting] run execute store result entity @e[tag=sb.item_drop,limit=1,sort=nearest,tag=!sb.completed] Motion[1] double 0.001 run data get entity @s Motion[1] 3000
+#Run the function on the new armor_stand to avoid multiple selectors.
+execute as @e[type=armor_stand,tag=sb.item_drop,distance=..1,limit=1,sort=nearest,tag=!sb.completed] run function items:as_place_2
 
-execute if entity @p[distance=..2,predicate=items:sprinting] run execute store result entity @e[tag=sb.item_drop,limit=1,sort=nearest,tag=!sb.completed] Motion[2] double 0.001 run data get entity @s Motion[2] 3000
-
-
-data modify entity @e[tag=sb.item_drop,limit=1,sort=nearest,tag=!sb.completed] HandItems[1] set from entity @s Item
-
-scoreboard players set @e[tag=sb.item_drop,limit=1,sort=nearest,tag=!sb.completed] sblifetime 1
-
-tag @s add sb.completed
-
+#Delete item
 kill @s
+

--- a/data/items/functions/as_place.mcfunction
+++ b/data/items/functions/as_place.mcfunction
@@ -8,10 +8,10 @@ scoreboard players add #as_count sb_items.data 1
 scoreboard players set #success sb_items.data 0
 execute store success score #success sb_items.data if entity @p[distance=..2,predicate=items:sprinting]
 
-#Store in a storage item nbt to avoid selector usage.
+#Store in a storage item nbt to avoid selector usage (@e).
 data modify storage items:main temp set from entity @s
 
-#Run the function on the new armor_stand to avoid multiple selectors.
+#Run the function on the new armor_stand to avoid multiple @e selectors.
 execute as @e[type=armor_stand,tag=sb.item_drop,distance=..1,limit=1,sort=nearest,tag=!sb.completed] run function items:as_place_2
 
 #Delete item

--- a/data/items/functions/as_place.mcfunction
+++ b/data/items/functions/as_place.mcfunction
@@ -1,10 +1,12 @@
 
 #Summon visual
-summon armor_stand ~ ~ ~ {ShowArms:1b,Pose:{LeftArm:[0f,0f,0f],RightArm:[0f,0f,0f]},Invisible:1b,Tags:["sb.item_drop","global.ignore.kill","global.ignore.pos","global.ignore"],Silent:1b,Invulnerable:1b}
+summon armor_stand ~ ~ ~ {ShowArms:1b,Pose:{LeftArm:[0f,0f,0f],RightArm:[0f,0f,0f]},Invisible:1b,Tags:["sb.item_drop","sb.check_ground","global.ignore.kill","global.ignore.pos","global.ignore"],Silent:1b,Invulnerable:1b}
+schedule function items:schedules/waiting_as_on_ground 1t replace
+scoreboard players add #as_count sb_items.data 1
 
 #Store result of player sprinting check
-scoreboard players set #success sb.lifetime 0
-execute store success score #success sb.lifetime if entity @p[distance=..2,predicate=items:sprinting]
+scoreboard players set #success sb_items.data 0
+execute store success score #success sb_items.data if entity @p[distance=..2,predicate=items:sprinting]
 
 #Store in a storage item nbt to avoid selector usage.
 data modify storage items:main temp set from entity @s

--- a/data/items/functions/as_place_2.mcfunction
+++ b/data/items/functions/as_place_2.mcfunction
@@ -1,0 +1,13 @@
+
+#Success 0 = no player sprinting nearby
+execute if score #success sb.lifetime matches 0 run data modify entity @s Motion set from storage items:main temp.Motion
+
+#Success 1 = player sprinting nearby
+execute if score #success sb.lifetime matches 1 store result entity @s Motion[0] double 1 run data get storage items:main temp.Motion[0] 3
+execute if score #success sb.lifetime matches 1 store result entity @s Motion[1] double 1 run data get storage items:main temp.Motion[1] 3
+execute if score #success sb.lifetime matches 1 store result entity @s Motion[2] double 1 run data get storage items:main temp.Motion[2] 3
+
+data modify entity @s HandItems[1] set from storage items:main temp.Item
+scoreboard players set @s sb.lifetime 1
+tag @s add sb.completed
+

--- a/data/items/functions/as_place_2.mcfunction
+++ b/data/items/functions/as_place_2.mcfunction
@@ -1,12 +1,13 @@
 
 #Success 0 = no player sprinting nearby
-execute if score #success sb.lifetime matches 0 run data modify entity @s Motion set from storage items:main temp.Motion
+execute if score #success sb_items.data matches 0 run data modify entity @s Motion set from storage items:main temp.Motion
 
 #Success 1 = player sprinting nearby
-execute if score #success sb.lifetime matches 1 store result entity @s Motion[0] double 1 run data get storage items:main temp.Motion[0] 3
-execute if score #success sb.lifetime matches 1 store result entity @s Motion[1] double 1 run data get storage items:main temp.Motion[1] 3
-execute if score #success sb.lifetime matches 1 store result entity @s Motion[2] double 1 run data get storage items:main temp.Motion[2] 3
+execute if score #success sb_items.data matches 1 store result entity @s Motion[0] double 1 run data get storage items:main temp.Motion[0] 3
+execute if score #success sb_items.data matches 1 store result entity @s Motion[1] double 1 run data get storage items:main temp.Motion[1] 3
+execute if score #success sb_items.data matches 1 store result entity @s Motion[2] double 1 run data get storage items:main temp.Motion[2] 3
 
+#Set visual item + scores
 data modify entity @s HandItems[1] set from storage items:main temp.Item
 scoreboard players set @s sb.lifetime 1
 tag @s add sb.completed

--- a/data/items/functions/despawn_score.mcfunction
+++ b/data/items/functions/despawn_score.mcfunction
@@ -1,0 +1,4 @@
+
+scoreboard players add @s sb.lifetime 1
+kill @s[scores={sb.lifetime=6000..}]
+

--- a/data/items/functions/if_break.mcfunction
+++ b/data/items/functions/if_break.mcfunction
@@ -1,3 +1,6 @@
+
 summon item ~ ~ ~ {Tags:["sb.pickup"],Item:{id:"minecraft:dirt",Count:1b},PickupDelay:1}
 data modify entity @e[type=item,tag=sb.pickup,limit=1,sort=nearest] Item set from entity @s Item
+scoreboard players remove #if_count sb_items.data 1
 kill @s
+

--- a/data/items/functions/if_loops.mcfunction
+++ b/data/items/functions/if_loops.mcfunction
@@ -1,0 +1,4 @@
+
+# Detecting a player nearby to drop the item
+execute if entity @a[distance=..1] run function items:if_break
+

--- a/data/items/functions/if_loops.mcfunction
+++ b/data/items/functions/if_loops.mcfunction
@@ -2,3 +2,6 @@
 # Detecting a player nearby to drop the item
 execute if entity @a[distance=..1] run function items:if_break
 
+# Despawning system
+execute if score .despawns ridsb.settings matches 1 if entity @s[tag=!global.ignore,tag=!global.ignore.kill] run function items:despawn_score
+

--- a/data/items/functions/if_place.mcfunction
+++ b/data/items/functions/if_place.mcfunction
@@ -2,6 +2,7 @@
 ## Turn the item into an item frame
 #Summon item_frame
 summon item_frame ~ ~ ~ {Facing:1b,Invisible:1b,Tags:["sb.item_flat","sb.temp"],Fixed:1b,Invulnerable:1b}
+scoreboard players add #if_count sb_items.data 1
 
 #Store in a storage item nbt to avoid selector usage (@e).
 data modify storage items:main temp set from entity @s Item

--- a/data/items/functions/if_place.mcfunction
+++ b/data/items/functions/if_place.mcfunction
@@ -3,7 +3,7 @@
 #Summon item_frame
 summon item_frame ~ ~ ~ {Facing:1b,Invisible:1b,Tags:["sb.item_flat","sb.temp"],Fixed:1b,Invulnerable:1b}
 
-#Store in a storage item nbt to avoid selector usage.
+#Store in a storage item nbt to avoid selector usage (@e).
 data modify storage items:main temp set from entity @s Item
 execute as @e[type=item_frame,tag=sb.temp,distance=..1,limit=1,sort=nearest] run function items:if_place_2
 

--- a/data/items/functions/if_place.mcfunction
+++ b/data/items/functions/if_place.mcfunction
@@ -1,4 +1,12 @@
-summon item_frame ~ ~ ~ {Facing:1b,Invisible:1b,Tags:["sb.item_flat"],Fixed:1b,Invulnerable:1b}
-data modify entity @e[type=item_frame,tag=sb.item_flat,limit=1,sort=nearest] Item set from entity @s Item
-tag @e[type=item_frame,tag=sb.item_flat,limit=1,sort=nearest] add on_floor
+
+## Turn the item into an item frame
+#Summon item_frame
+summon item_frame ~ ~ ~ {Facing:1b,Invisible:1b,Tags:["sb.item_flat","sb.temp"],Fixed:1b,Invulnerable:1b}
+
+#Store in a storage item nbt to avoid selector usage.
+data modify storage items:main temp set from entity @s Item
+execute as @e[type=item_frame,tag=sb.temp,distance=..1,limit=1,sort=nearest] run function items:if_place_2
+
+#Delete item
 kill @s
+

--- a/data/items/functions/if_place.mcfunction
+++ b/data/items/functions/if_place.mcfunction
@@ -2,6 +2,7 @@
 ## Turn the item into an item frame
 #Summon item_frame
 summon item_frame ~ ~ ~ {Facing:1b,Invisible:1b,Tags:["sb.item_flat","sb.temp"],Fixed:1b,Invulnerable:1b}
+schedule function items:schedules/if_loops 1t replace
 scoreboard players add #if_count sb_items.data 1
 
 #Store in a storage item nbt to avoid selector usage (@e).

--- a/data/items/functions/if_place_2.mcfunction
+++ b/data/items/functions/if_place_2.mcfunction
@@ -1,5 +1,4 @@
 
 data modify entity @s Item set from storage items:main temp
-tag @s add sb.on_floor
 tag @s remove sb.temp
 

--- a/data/items/functions/if_place_2.mcfunction
+++ b/data/items/functions/if_place_2.mcfunction
@@ -1,0 +1,5 @@
+
+data modify entity @s Item set from storage items:main temp
+tag @s add sb.on_floor
+tag @s remove sb.temp
+

--- a/data/items/functions/load.mcfunction
+++ b/data/items/functions/load.mcfunction
@@ -8,3 +8,6 @@ execute store success score .settings ridsb.initcheck run scoreboard objectives 
 execute unless score .settings ridsb.initcheck matches 0 run scoreboard players set .display ridsb.settings 0
  
 scoreboard objectives add sb.lifetime dummy
+
+#define storage items:main
+

--- a/data/items/functions/load.mcfunction
+++ b/data/items/functions/load.mcfunction
@@ -1,4 +1,5 @@
 # Scoreboards
+scoreboard objectives add sb_items.data dummy
 scoreboard objectives add ridsb.initcheck dummy
 
 execute store success score .uninstall ridsb.initcheck run scoreboard objectives add ridsb.uninstalled dummy
@@ -8,6 +9,7 @@ execute store success score .settings ridsb.initcheck run scoreboard objectives 
 execute unless score .settings ridsb.initcheck matches 0 run scoreboard players set .display ridsb.settings 0
  
 scoreboard objectives add sb.lifetime dummy
+schedule function items:schedules/loop_5s 5s replace
 
 #define storage items:main
 

--- a/data/items/functions/load.mcfunction
+++ b/data/items/functions/load.mcfunction
@@ -9,7 +9,7 @@ execute store success score .settings ridsb.initcheck run scoreboard objectives 
 execute unless score .settings ridsb.initcheck matches 0 run scoreboard players set .display ridsb.settings 0
  
 scoreboard objectives add sb.lifetime dummy
-schedule function items:schedules/loop_5s 5s replace
+function items:schedules/loop_5s
 
 #define storage items:main
 

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -6,7 +6,6 @@
 execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
 execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
-execute as @e[type=armor_stand,nbt={OnGround:1b},predicate=!items:imang,tag=sb.item_drop] run data merge entity @s {NoGravity:1b,Marker:1b}
 execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
 
 # Detecting distance

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -1,14 +1,19 @@
+
 # DROPPING
-execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
-execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
+#display 0 = armor_stand
+#display 1 = item_frame
+#display 2 = default (item)
+execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
+execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
 execute as @e[type=armor_stand,nbt={OnGround:1b},predicate=!items:imang,tag=sb.item_drop] run data merge entity @s {NoGravity:1b,Marker:1b}
 execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
 
 # Detecting distance
 execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if entity @e[type=player,distance=..1.2] run function items:as_break
-execute as @e[tag=on_floor,tag=sb.item_flat] at @s if entity @a[distance=..1] run function items:if_break
+execute as @e[tag=sb.on_floor,tag=sb.item_flat] at @s if entity @a[distance=..1] run function items:if_break
 
 execute if score .despawns ridsb.settings matches 1 run scoreboard players add @e[tag=sb.item_drop] sb.lifetime 1
 
 kill @e[scores={sb.lifetime=6000..},tag=!global.ignore,tag=!global.ignore.kill]
+

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -1,13 +1,12 @@
 
-# DROPPING system
-#display 0 = armor_stand
-#display 1 = item_frame
-#display 2 = default (item)
+## DROPPING system
+# display 0 = armor_stand
+# display 1 = item_frame
+# display 2 = default (item)
 execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
 execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
-# Detecting distance
-execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if entity @e[type=player,distance=..1.2] run function items:as_break
+## Detecting distance
 execute as @e[tag=sb.on_floor,tag=sb.item_flat] at @s if entity @a[distance=..1] run function items:if_break
 
 execute if score .despawns ridsb.settings matches 1 run scoreboard players add @e[tag=sb.item_drop] sb.lifetime 1

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -1,12 +1,10 @@
 
-# DROPPING
+# DROPPING system
 #display 0 = armor_stand
 #display 1 = item_frame
 #display 2 = default (item)
 execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
 execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
-
-execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
 
 # Detecting distance
 execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if entity @e[type=player,distance=..1.2] run function items:as_break

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -6,3 +6,8 @@
 execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
 execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
+## Suggestion: only affect items close to a player to allow hopper and other stuff to work properly
+## uncomment the following lines to enable this and comment out the lines above
+#execute if score .display ridsb.settings matches 0 at @a as @e[type=item,distance=..16,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
+#execute if score .display ridsb.settings matches 1 at @a as @e[type=item,distance=..16,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
+

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -6,9 +6,6 @@
 execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
 execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
-## Detecting distance
-execute as @e[tag=sb.on_floor,tag=sb.item_flat] at @s if entity @a[distance=..1] run function items:if_break
-
 execute if score .despawns ridsb.settings matches 1 run scoreboard players add @e[tag=sb.item_drop] sb.lifetime 1
 
 kill @e[scores={sb.lifetime=6000..},tag=!global.ignore,tag=!global.ignore.kill]

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -1,6 +1,6 @@
 # DROPPING
-execute as @e[type=item,tag=!pickup,tag=!global.ignore,predicate=items:2s] at @s if score .display ridsb.settings matches 0 run function items:as_place
-execute as @e[type=item,predicate=items:if_check,tag=!pickup,tag=!global.ignore] at @s if score .display ridsb.settings matches 1 unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
+execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
+execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
 execute as @e[type=armor_stand,nbt={OnGround:1b},predicate=!items:imang,tag=sb.item_drop] run data merge entity @s {NoGravity:1b,Marker:1b}
 execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~

--- a/data/items/functions/loop.mcfunction
+++ b/data/items/functions/loop.mcfunction
@@ -6,7 +6,3 @@
 execute if score .display ridsb.settings matches 0 as @e[type=item,tag=!sb.pickup,tag=!global.ignore,predicate=items:2s] at @s run function items:as_place
 execute if score .display ridsb.settings matches 1 as @e[type=item,predicate=items:if_check,tag=!sb.pickup,tag=!global.ignore] at @s unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
 
-execute if score .despawns ridsb.settings matches 1 run scoreboard players add @e[tag=sb.item_drop] sb.lifetime 1
-
-kill @e[scores={sb.lifetime=6000..},tag=!global.ignore,tag=!global.ignore.kill]
-

--- a/data/items/functions/schedules/as_gravity.mcfunction
+++ b/data/items/functions/schedules/as_gravity.mcfunction
@@ -1,0 +1,7 @@
+
+# Armor stand manual gravity to put the entity in the floor
+execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
+
+# Loop again if there are remaining armor_stands that needs to be checked (auto stopped by items:schedules/loop_5s)
+execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_gravity 1t replace
+

--- a/data/items/functions/schedules/as_gravity_loops.mcfunction
+++ b/data/items/functions/schedules/as_gravity_loops.mcfunction
@@ -1,9 +1,6 @@
 
-# Armor stand manual gravity to put the entity in the floor
-execute as @e[type=armor_stand,tag=sb.is_marker] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
-
-# Detecting a player nearby to drop the item
-execute as @e[type=armor_stand,tag=sb.is_marker] at @s if entity @e[type=player,distance=..1.2] run function items:as_break
+# Armor stand loops
+execute as @e[type=armor_stand,tag=sb.is_marker] at @s run function items:as_loops
 
 # Loop again if there are remaining armor_stands that needs to be checked (auto stopped by items:schedules/loop_5s)
 execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_gravity 1t replace

--- a/data/items/functions/schedules/as_gravity_loops.mcfunction
+++ b/data/items/functions/schedules/as_gravity_loops.mcfunction
@@ -1,6 +1,9 @@
 
 # Armor stand manual gravity to put the entity in the floor
-execute as @e[tag=sb.item_drop,predicate=items:imang] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
+execute as @e[type=armor_stand,tag=sb.is_marker] at @s if block ~ ~0.8 ~ #items:ignore run tp @s ~ ~-0.2 ~
+
+# Detecting a player nearby to drop the item
+execute as @e[type=armor_stand,tag=sb.is_marker] at @s if entity @e[type=player,distance=..1.2] run function items:as_break
 
 # Loop again if there are remaining armor_stands that needs to be checked (auto stopped by items:schedules/loop_5s)
 execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_gravity 1t replace

--- a/data/items/functions/schedules/as_loops.mcfunction
+++ b/data/items/functions/schedules/as_loops.mcfunction
@@ -3,5 +3,5 @@
 execute as @e[type=armor_stand,tag=sb.is_marker] at @s run function items:as_loops
 
 # Loop again if there are remaining armor_stands that needs to be checked (auto stopped by items:schedules/loop_5s)
-execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_gravity 1t replace
+execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_loops 1t replace
 

--- a/data/items/functions/schedules/if_loops.mcfunction
+++ b/data/items/functions/schedules/if_loops.mcfunction
@@ -1,0 +1,7 @@
+
+# Item frame loops
+execute as @e[type=item_frame,tag=sb.item_flat] at @s run function items:if_loops
+
+# Loop again if there are remaining armor_stands that needs to be checked (auto stopped by items:schedules/loop_5s)
+execute if score #if_count sb_items.data matches 1.. run schedule function items:schedules/if_loops 1t replace
+

--- a/data/items/functions/schedules/loop_5s.mcfunction
+++ b/data/items/functions/schedules/loop_5s.mcfunction
@@ -1,9 +1,15 @@
 
 # Store numbers of entity to launch proper schedules
 execute store result score #as_count sb_items.data if entity @e[type=armor_stand,tag=sb.check_ground]
+execute store result score #as_marker_count sb_items.data if entity @e[type=armor_stand,tag=sb.is_marker]
 
-# Loops
+# Start / Restart Loops
 execute if score #as_count sb_items.data matches 1.. run schedule function items:schedules/waiting_as_on_ground 1t replace
+execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_gravity 1t replace
+
+# Stop Loops
+execute if score #as_count sb_items.data matches 0 run schedule clear items:schedules/stop_waiting_as_on_ground
+execute if score #as_marker_count sb_items.data matches 0 run schedule clear items:schedules/stop_as_gravity
 
 # Loop again!
 schedule function items:schedules/loop_5s 5s replace

--- a/data/items/functions/schedules/loop_5s.mcfunction
+++ b/data/items/functions/schedules/loop_5s.mcfunction
@@ -5,11 +5,11 @@ execute store result score #as_marker_count sb_items.data if entity @e[type=armo
 
 # Start / Restart Loops
 execute if score #as_count sb_items.data matches 1.. run schedule function items:schedules/waiting_as_on_ground 1t replace
-execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_gravity 1t replace
+execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_loop 1t replace
 
 # Stop Loops
-execute if score #as_count sb_items.data matches 0 run schedule clear items:schedules/stop_waiting_as_on_ground
-execute if score #as_marker_count sb_items.data matches 0 run schedule clear items:schedules/stop_as_gravity
+execute if score #as_count sb_items.data matches 0 run schedule clear items:schedules/waiting_as_on_ground
+execute if score #as_marker_count sb_items.data matches 0 run schedule clear items:schedules/as_loops
 
 # Loop again!
 schedule function items:schedules/loop_5s 5s replace

--- a/data/items/functions/schedules/loop_5s.mcfunction
+++ b/data/items/functions/schedules/loop_5s.mcfunction
@@ -1,15 +1,22 @@
 
+## Loop 5s
+## As soon as an entity is detected, it will launch the proper loop
+## Avoiding useless tick loops using @e with no results
+
 # Store numbers of entity to launch proper schedules
 execute store result score #as_count sb_items.data if entity @e[type=armor_stand,tag=sb.check_ground]
 execute store result score #as_marker_count sb_items.data if entity @e[type=armor_stand,tag=sb.is_marker]
+execute store result score #if_count sb_items.data if entity @e[type=item_frame,tag=sb.item_flat]
 
 # Start / Restart Loops
 execute if score #as_count sb_items.data matches 1.. run schedule function items:schedules/waiting_as_on_ground 1t replace
-execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_loop 1t replace
+execute if score #as_marker_count sb_items.data matches 1.. run schedule function items:schedules/as_loops 1t replace
+execute if score #if_count sb_items.data matches 1.. run schedule function items:schedules/if_loops 1t replace
 
 # Stop Loops
 execute if score #as_count sb_items.data matches 0 run schedule clear items:schedules/waiting_as_on_ground
 execute if score #as_marker_count sb_items.data matches 0 run schedule clear items:schedules/as_loops
+execute if score #if_count sb_items.data matches 0 run schedule clear items:schedules/if_loops
 
 # Loop again!
 schedule function items:schedules/loop_5s 5s replace

--- a/data/items/functions/schedules/loop_5s.mcfunction
+++ b/data/items/functions/schedules/loop_5s.mcfunction
@@ -1,0 +1,10 @@
+
+# Store numbers of entity to launch proper schedules
+execute store result score #as_count sb_items.data if entity @e[type=armor_stand,tag=sb.check_ground]
+
+# Loops
+execute if score #as_count sb_items.data matches 1.. run schedule function items:schedules/waiting_as_on_ground 1t replace
+
+# Loop again!
+schedule function items:schedules/loop_5s 5s replace
+

--- a/data/items/functions/schedules/waiting_as_on_ground.mcfunction
+++ b/data/items/functions/schedules/waiting_as_on_ground.mcfunction
@@ -1,0 +1,7 @@
+
+# Set an armor_stand marker's nbt when it is on the ground
+execute as @e[type=armor_stand,tag=sb.check_ground,predicate=items:on_ground] run function items:as_on_ground
+
+# Loop again if there are remaining armor_stands that needs to be checked
+execute if score #as_count sb_items.data matches 1.. run schedule function items:schedules/waiting_as_on_ground 1t replace
+

--- a/data/items/predicates/imang.json
+++ b/data/items/predicates/imang.json
@@ -1,8 +1,0 @@
-{
-    "condition": "minecraft:entity_properties",
-    "entity": "this",
-    "predicate": {
-      "nbt": "{Marker:1b,NoGravity:1b}"
-    }
-  }
-  

--- a/data/items/predicates/on_ground.json
+++ b/data/items/predicates/on_ground.json
@@ -1,0 +1,7 @@
+{
+	"condition": "minecraft:entity_properties",
+	"entity": "this",
+	"predicate": {
+		"nbt": "{OnGround:1b}"
+	}
+}


### PR DESCRIPTION
Hello 👋 !
I was looking up Modrinth datapacks and I saw this one. I remembered I tested it a few time ago and noticed huge lags coming from this datapack. So I clicked to see the source code and my instinct took over me and here I come.

I directly noticed a fast optimisation that could be done and after fixed it, I decided to optimise the whole datapack.
By before I say anything, small warning: keep in mind that I do not do this to show that I am better than anyone else. I am just impassioned by optimisations and fast running programs.
So, now that it has been said. Let me introduce you what I changed and why.



## Firstly
I noticed those 2 lines in the loop function:
```mcfunction
execute as @e[type=item,tag=!pickup,tag=!global.ignore,predicate=items:2s] at @s if score .display ridsb.settings matches 0 run function items:as_place
execute as @e[type=item,predicate=items:if_check,tag=!pickup,tag=!global.ignore] at @s if score .display ridsb.settings matches 1 unless block ~ ~-0.1 ~ #items:ignore unless entity @e[type=item_frame,distance=..1] run function items:if_place
```
Optimisation done: checking the constant score before executing `@e` selector, avoiding 2 selectors instead of one and removing constant instruction multiplication :
Let's say we use the armor_stand system and the selector found 3 items to process. By using your line, the code will execute like this:
```mcfunction
execute as @e[type=item,tag=!pickup,tag=!global.ignore,predicate=items:2s]
    at @s if score .display ridsb.settings matches 0 run function items:as_place
    at @s if score .display ridsb.settings matches 0 run function items:as_place
    at @s if score .display ridsb.settings matches 0 run function items:as_place
```
But with my line, the `if score .display ridsb.settings matches 0` instruction will only be executed one time.



## Secondly
Placements have been optimised by using storage and running functions using `as` to prevent multiple @e usage.
(This can take time to explain but you will understand easily by taking a look at commits)



## Thirdly
Why should we run selectors when we know for sure there are no armor stands or item frames?
So I created schedules that run only when an entity of their type is detected:
- `items:schedules/waiting_as_on_ground` for first state armor stands (the ones that are falling)
- `items:schedules/as_loops` tick loop runned on every second state armor stands
- `items:schedules/if_loops` same but for item frames
With that, I could centralise breaking functions too.



## Fourthly
I also centralized the despawning system. By doing that I noticed that item frames weren't affected. I corrected it but if it is a feature then you can delete the line in the `items:if_loops` function.



## Fifthly
I did global optimisations all over the files, sometime by using a success score to avoid multiple selectors all over.


# Finally
I would suggest something. As this is a visual enhancement, I don't think items far from players should be affected.
In the `items:loop` function, I wrote in comments the code that will only touch close items from players.
I highly recommend to do it because current system will break farms using hoppers and put a high amount of non-item entities. Applying this suggestion will also be benefit for performance.


If you have any question or anything you want me to precise more, feel free to ask here or by adding friend on discord as I can't add you : @ Stoupy51#2679



